### PR TITLE
Parse IBM Service Credentials from JSON

### DIFF
--- a/assets/test/ibm_service_creds.json
+++ b/assets/test/ibm_service_creds.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://stream.watsonplatform.net/speech-to-text/api",
+  "username": "9f6cdead-d9d3-49db-96e4-deadbeefdead",
+  "password": "8rgJeCunnie8"
+}

--- a/ibmservicecreds/ibmservicecreds.go
+++ b/ibmservicecreds/ibmservicecreds.go
@@ -1,0 +1,34 @@
+package ibmservicecreds
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+type IBMServiceCreds struct {
+	Url      string `json:"url"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+func ReadCredsFromPath(path string) (IBMServiceCreds, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		panic(err)
+	}
+	return ReadCredsFromReader(file)
+}
+func ReadCredsFromReader(r io.Reader) (creds IBMServiceCreds, err error) {
+	buf := []byte{}
+	buf, err = ioutil.ReadAll(r)
+	if err != nil {
+		panic(err)
+	}
+	json.Unmarshal(buf, &creds)
+	if err != nil {
+		panic(err)
+	}
+	return creds, err
+}

--- a/ibmservicecreds/ibmservicecreds_suite_test.go
+++ b/ibmservicecreds/ibmservicecreds_suite_test.go
@@ -1,0 +1,13 @@
+package ibmservicecreds_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestIbmservicecreds(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Ibmservicecreds Suite")
+}

--- a/ibmservicecreds/ibmservicecreds_test.go
+++ b/ibmservicecreds/ibmservicecreds_test.go
@@ -1,0 +1,61 @@
+package ibmservicecreds_test
+
+import (
+	. "github.com/blabbertabber/DiarizerServer/ibmservicecreds"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"io/ioutil"
+	"strings"
+)
+
+var _ = Describe("IBMServiceCreds", func() {
+	Context(".ReadCredsFromReader", func() {
+		Context("When a reader is passed an empty JSON", func() {
+			It("returns an empty struct", func() {
+				sourceReader := strings.NewReader("{}")
+				expectation := IBMServiceCreds{}
+				readCreds, err := ReadCredsFromReader(sourceReader)
+				Expect(err).To(BeNil())
+				Expect(readCreds).To(Equal(expectation))
+			})
+		})
+		Context("When a reader is passed a populated JSON", func() {
+			It("returns a populated struct", func() {
+				source, err := ioutil.ReadFile("../assets/test/ibm_service_creds.json")
+				Expect(err).To(BeNil())
+				sourceReader := strings.NewReader(string(source))
+				expectation := IBMServiceCreds{
+					Url:      "https://stream.watsonplatform.net/speech-to-text/api",
+					Username: "9f6cdead-d9d3-49db-96e4-deadbeefdead",
+					Password: "8rgJeCunnie8",
+				}
+				readCreds, err := ReadCredsFromReader(sourceReader)
+				Expect(err).To(BeNil())
+				Expect(readCreds).To(Equal(expectation))
+			})
+		})
+	})
+	Context(".ReadCredsFromPath", func() {
+		Context("When path is exists and is valid JSON", func() {
+			It("returns the expected struct", func() {
+				readCreds, err := ReadCredsFromPath("../assets/test/ibm_service_creds.json")
+				Expect(err).To(BeNil())
+				expectation := IBMServiceCreds{
+					Url:      "https://stream.watsonplatform.net/speech-to-text/api",
+					Username: "9f6cdead-d9d3-49db-96e4-deadbeefdead",
+					Password: "8rgJeCunnie8",
+				}
+				Expect(readCreds).To(Equal(expectation))
+			})
+		})
+		Context("When path is non-existent", func() {
+			It("panics", func() {
+				Expect(func() {
+					ReadCredsFromPath("/non/existent/path")
+				}).Should(Panic())
+			})
+		})
+	})
+
+})


### PR DESCRIPTION
- will be a flag passed to the Diarizer Server that points
  to the JSON file with credentials, e.g.
  `./DiarizerServer -IBMCredFile /var/blabbertabber/ibm.json`
- This lays the groundwork for the DiarizerServer to pass
  the IBM Credentials to the Docker container which will
  upload the meeting.wav file to IBM & download the JSON results