### PR TITLE
Lay groundwork for testing HTTP handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,13 @@ var keyPath = filepath.FromSlash("/etc/pki/nginx/private/server.key")
 var certPath = filepath.FromSlash("/etc/pki/nginx/server.crt")
 
 func main() {
-	http.HandleFunc("/api/v1/upload", httphandler.New().Handler)
+	h := httphandler.HttpHandler{
+		Uuid:           httphandler.UuidReal{},
+		DockerRunner:   httphandler.DockerRunnerReal{},
+		SoundRootDir:   filepath.FromSlash("/var/blabbertabber/soundFiles/"),
+		ResultsRootDir: filepath.FromSlash("/var/blabbertabber/diarizationResults/"),
+	}
+	http.HandleFunc("/api/v1/upload", h.Handler)
 
 	go func() {
 		log.Fatal(http.ListenAndServe(CLEAR_PORT, nil))


### PR DESCRIPTION
- UUID generation becomes interface
- Docker runner becomes an interface
- UUID & Docker runner are part of handler struct (and so are paths)

This reddit thread was much of the inspiration:

https://www.reddit.com/r/golang/comments/4nhrot/how_are_you_passing_dependencies_to_your_handlers/

And so was this Go Playground:

https://play.golang.org/p/yP4qDWx-3y

Tested on test.diarizer.com — it works!