### PR TITLE
IBM Speech to Text works properly end-to-end

### DIFF
--- a/assets/ibm-watson-stt/Dockerfile
+++ b/assets/ibm-watson-stt/Dockerfile
@@ -1,5 +1,5 @@
 # This is a Dockerfile of IBM 4 + custom patched file
-#  - only 1 alternative (i.e. no alternatives, just one version)
+#  - only 1 transcription version (alternative) (i.e. no alternatives, just one version)
 #  - enable diarization
 #  - don't worry about continuous (streaming)/interim results
 

--- a/cmdrunner/cmdrunner.go
+++ b/cmdrunner/cmdrunner.go
@@ -13,9 +13,7 @@ type CmdRunner interface {
 	Run(cmdArgs ...string)
 }
 
-type CmdRunnerReal struct {
-	logger log.Logger
-}
+type CmdRunnerReal struct{}
 
 func (d CmdRunnerReal) Run(cmdArgs ...string) {
 	command := exec.Command(cmdArgs[0], cmdArgs[1:]...)

--- a/cmdrunner/cmdrunner.go
+++ b/cmdrunner/cmdrunner.go
@@ -4,7 +4,6 @@
 package cmdrunner
 
 import (
-	"io/ioutil"
 	"log"
 	"os/exec"
 )
@@ -14,23 +13,16 @@ type CmdRunner interface {
 	Run(cmdArgs ...string)
 }
 
-type CmdRunnerReal struct{}
+type CmdRunnerReal struct {
+	logger log.Logger
+}
 
 func (d CmdRunnerReal) Run(cmdArgs ...string) {
 	command := exec.Command(cmdArgs[0], cmdArgs[1:]...)
-	stderr, err := command.StderrPipe()
+	stdOutStdErr, err := command.CombinedOutput()
+	log.Println(cmdArgs)
+	log.Println(string(stdOutStdErr))
 	if err != nil {
-		panic(err)
-	}
-
-	if err := command.Start(); err != nil {
-		panic(err)
-	}
-
-	slurp, _ := ioutil.ReadAll(stderr)
-	log.Printf("%s\n", slurp)
-
-	if err := command.Wait(); err != nil {
-		panic(err)
+		log.Panic(err)
 	}
 }

--- a/diarizerrunner/diarizerrunner.go
+++ b/diarizerrunner/diarizerrunner.go
@@ -62,10 +62,8 @@ func (r Runner) Run(flavor, meetingUuid string, creds ibmservicecreds.IBMService
 			IBMCmd := []string{
 				"bash",
 				"-c",
-				"echo",
-				fmt.Sprintf("/blabbertabber/soundFiles/%s/meeting.wav", meetingUuid),
-				">",
-				fmt.Sprintf("/blabbertabber/soundFiles/%s/wav_file_list.txt", meetingUuid),
+				fmt.Sprintf("echo /blabbertabber/soundFiles/%s/meeting.wav"+
+					" > /var/blabbertabber/soundFiles/%s/wav_file_list.txt", meetingUuid, meetingUuid),
 			}
 			r.CmdRunner.Run(IBMCmd...)
 			IBMCmd = []string{
@@ -86,11 +84,11 @@ func (r Runner) Run(flavor, meetingUuid string, creds ibmservicecreds.IBMService
 			}
 			r.CmdRunner.Run(IBMCmd...)
 			IBMCmd = []string{
-				"ibmjson",
+				"/usr/local/bin/ibmjson",
 				"-in",
-				fmt.Sprintf("/blabbertabber/diarizationResults/%s/ibm_out/0.json.txt", meetingUuid),
+				fmt.Sprintf("/var/blabbertabber/diarizationResults/%s/ibm_out/0.json.txt", meetingUuid),
 				"-out",
-				fmt.Sprintf("/blabbertabber/diarizationResults/%s/ibm_out.json", meetingUuid),
+				fmt.Sprintf("/var/blabbertabber/diarizationResults/%s/ibm_out.json", meetingUuid),
 			}
 			r.CmdRunner.Run(IBMCmd...)
 		}

--- a/diarizerrunner/diarizerrunner.go
+++ b/diarizerrunner/diarizerrunner.go
@@ -60,20 +60,37 @@ func (r Runner) Run(flavor, meetingUuid string, creds ibmservicecreds.IBMService
 				return errors.New("invalid IBM creds")
 			}
 			IBMCmd := []string{
+				"bash",
+				"-c",
+				"echo",
+				fmt.Sprintf("/blabbertabber/soundFiles/%s/meeting.wav", meetingUuid),
+				">",
+				fmt.Sprintf("/blabbertabber/soundFiles/%s/wav_file_list.txt", meetingUuid),
+			}
+			r.CmdRunner.Run(IBMCmd...)
+			IBMCmd = []string{
 				"docker",
 				"run",
 				"--volume=/var/blabbertabber:/blabbertabber",
 				"blabbertabber/ibm-watson-stt",
 				"python",
-				"/sttClient.py",
+				"/speech-to-text-websockets-python/sttClient.py",
 				"-credentials",
 				creds.Username + ":" + creds.Password,
 				"-model",
 				"en-US_NarrowbandModel",
 				"-in",
-				fmt.Sprintf("/blabbertabber/soundFiles/%s/meeting.wav", meetingUuid),
+				fmt.Sprintf("/blabbertabber/soundFiles/%s/wav_file_list.txt", meetingUuid),
 				"-out",
-				fmt.Sprintf("/blabbertabber/diarizationResults/%s", meetingUuid),
+				fmt.Sprintf("/blabbertabber/diarizationResults/%s/ibm_out", meetingUuid),
+			}
+			r.CmdRunner.Run(IBMCmd...)
+			IBMCmd = []string{
+				"ibmjson",
+				"-in",
+				fmt.Sprintf("/blabbertabber/diarizationResults/%s/ibm_out/0.json.txt", meetingUuid),
+				"-out",
+				fmt.Sprintf("/blabbertabber/diarizationResults/%s/ibm_out.json", meetingUuid),
 			}
 			r.CmdRunner.Run(IBMCmd...)
 		}

--- a/diarizerrunner/diarizerrunner_test.go
+++ b/diarizerrunner/diarizerrunner_test.go
@@ -64,10 +64,7 @@ var _ = Describe("diarizerrunner", func() {
 			Expect(fdr.RunArgsForCall(0)).To(Equal([]string{
 				"bash",
 				"-c",
-				"echo",
-				"/blabbertabber/soundFiles/fake-uuid/meeting.wav",
-				">",
-				"/blabbertabber/soundFiles/fake-uuid/wav_file_list.txt",
+				"echo /blabbertabber/soundFiles/fake-uuid/meeting.wav > /var/blabbertabber/soundFiles/fake-uuid/wav_file_list.txt",
 			}))
 			Expect(fdr.RunArgsForCall(1)).To(Equal([]string{
 				"docker",
@@ -86,11 +83,11 @@ var _ = Describe("diarizerrunner", func() {
 				"/blabbertabber/diarizationResults/fake-uuid/ibm_out",
 			}))
 			Expect(fdr.RunArgsForCall(2)).To(Equal([]string{
-				"ibmjson",
+				"/usr/local/bin/ibmjson",
 				"-in",
-				"/blabbertabber/diarizationResults/fake-uuid/ibm_out/0.json.txt",
+				"/var/blabbertabber/diarizationResults/fake-uuid/ibm_out/0.json.txt",
 				"-out",
-				"/blabbertabber/diarizationResults/fake-uuid/ibm_out.json",
+				"/var/blabbertabber/diarizationResults/fake-uuid/ibm_out.json",
 			}))
 		})
 		Context("when there are no credentials passed", func() {

--- a/diarizerrunner/diarizerrunner_test.go
+++ b/diarizerrunner/diarizerrunner_test.go
@@ -59,23 +59,38 @@ var _ = Describe("diarizerrunner", func() {
 		})
 	})
 	Context("When the runner is \"IBM\"", func() {
-		It("runs Docker with the correct arguments", func() {
+		It("runs several commands with the correct arguments", func() {
 			Expect(r.Run("IBM", "fake-uuid", creds)).To(BeNil())
 			Expect(fdr.RunArgsForCall(0)).To(Equal([]string{
+				"bash",
+				"-c",
+				"echo",
+				"/blabbertabber/soundFiles/fake-uuid/meeting.wav",
+				">",
+				"/blabbertabber/soundFiles/fake-uuid/wav_file_list.txt",
+			}))
+			Expect(fdr.RunArgsForCall(1)).To(Equal([]string{
 				"docker",
 				"run",
 				"--volume=/var/blabbertabber:/blabbertabber",
 				"blabbertabber/ibm-watson-stt",
 				"python",
-				"/sttClient.py",
+				"/speech-to-text-websockets-python/sttClient.py",
 				"-credentials",
 				"fake-ibm-username:fake-ibm-password",
 				"-model",
 				"en-US_NarrowbandModel",
 				"-in",
-				"/blabbertabber/soundFiles/fake-uuid/meeting.wav",
+				"/blabbertabber/soundFiles/fake-uuid/wav_file_list.txt",
 				"-out",
-				"/blabbertabber/diarizationResults/fake-uuid",
+				"/blabbertabber/diarizationResults/fake-uuid/ibm_out",
+			}))
+			Expect(fdr.RunArgsForCall(2)).To(Equal([]string{
+				"ibmjson",
+				"-in",
+				"/blabbertabber/diarizationResults/fake-uuid/ibm_out/0.json.txt",
+				"-out",
+				"/blabbertabber/diarizationResults/fake-uuid/ibm_out.json",
 			}))
 		})
 		Context("when there are no credentials passed", func() {


### PR DESCRIPTION
IBM Commands have correct paths

- commands within a Docker container use `/blabbertabber`
  regular commands use `/var/blabbertabber`
- `bash -c` requires ONE argument, not many
  (e.g. `exec.Command("bash", "-c", "echo 'I love you' > /tmp/j.txt")
  (args past ONE become positional params, i.e. $1, $2, etc...)
- `ibmjson` has absolute pathname
- `wav_file_list.txt` has correct pathnames within

fixes:
```
panic: exec: "ibmjson": executable file not found in $PATH
```

fixes:
```
exceptions.IOError: [Errno 2] No such file or directory: '/var/blabbertabber/soundFiles/8d153662-93cd-4a63-9821-d6cf76d14e45/meeting.wav'
```

cmdrunner logs output for better debugging

- also clarified comments for the IBM Dockerfile
  (i.e. "alternative" -> "alternative transcriptions")

IBM Diarization is properly invoked

- needs 3 commands, not one
  - create the list of .wav files
  - invoke docker to diarizer (`docker run`)
  - post-processing (`ibmjson`)
