### PR TITLE
`diarizer` service _must_ be in `docker` group

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -24,11 +24,13 @@ ssh -i /c/Users/saint/.ssh/id_github saintbrendan@test.diarizer.com
 cd $GOPATH/src/github.com/blabbertabber/speechbroker
 git pull -r
 go build
+sudo setcap cap_setgid+ep speechbroker
 sudo systemctl stop diarizer.service
 sudo -u diarizer ./speechbroker -ibmServiceCredsPath=/etc/ibm_service_creds.json
  # run BlabberTabber, upload file, check output -- .txt files there?
  # if not, debug and repeat
 sudo cp speechbroker /usr/local/bin/
+sudo setcap cap_setgid+ep /usr/local/bin/speechbroker
 sudo systemctl start diarizer.service
 ```
 
@@ -40,11 +42,13 @@ ssh -i /c/Users/saint/.ssh/id_github saintbrendan@diarizer.com
 cd $GOPATH/src/github.com/blabbertabber/speechbroker
 git pull -r
 go build
+sudo setcap cap_setgid+ep speechbroker
 sudo systemctl stop diarizer.service
 sudo -u diarizer ./speechbroker -ibmServiceCredsPath=/etc/ibm_service_creds.json
  # run BlabberTabber, upload file, check output -- .txt files there?
  # if not, debug and repeat
 sudo cp speechbroker /usr/local/bin/
+sudo setcap cap_setgid+ep /usr/local/bin/speechbroker
 sudo systemctl start diarizer.service
 ```
 


### PR DESCRIPTION
- otherwise it can't spin up containers
- can't switch primary GID to `docker` from `diarizer` because
  `diarizer` membership is required for reading private SSL keys

fixes:
```
Aug  6 08:12:53 test speechbroker: docker: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Post http://%2Fvar%2Frun%2Fdocker.sock/v1.30/containers/create: dial unix /var/run/docker.sock: connect: permission denied.
```