### PR TITLE
Diarizer server starts after upgrade to Fedora26

### DIFF
--- a/assets/diarizer.service
+++ b/assets/diarizer.service
@@ -1,10 +1,14 @@
 [Unit]
 Description=Diarizer server which diarizes files uploaded to it
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/speechbroker -ibmServiceCredsPath=/etc/ibm_service_creds.json
 Restart=always
-           
+User=diarizer
+Group=diarizer
+
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/docs/server_setup.md
+++ b/docs/server_setup.md
@@ -334,15 +334,13 @@ cd
 mkdir go
 go get github.com/blabbertabber/speechbroker/
 go build github.com/blabbertabber/speechbroker
-go build github.com/blabbertabber/speechbroker/ibmjson
-sudo cp speechbroker ibmjson /usr/local/bin/
-sudo chown diarizer:diarizer /usr/local/bin/speechbroker
- # the following is bad; should have other ways to set uid
-sudo chown diarizer:diarizer /usr/local/bin/speechbroker
-sudo chmod 6755 /usr/local/bin/speechbroker
-sudo cp assets/diarizer.service /etc/systemd/system/
+go build -o /tmp/ibmjson github.com/blabbertabber/speechbroker/ibmjson
+sudo cp speechbroker /tmp/ibmjson /usr/local/bin/
+sudo setcap cap_setgid+ep /usr/local/bin/speechbroker
+sudo cp assets/diarizer.service /usr/lib/systemd/system/
+echo enable diarizer.service | sudo tee /usr/lib/systemd/system-preset/50-diarizer.preset
 sudo systemctl daemon-reload
-sudo systemctl enable --now diarizer.service
+sudo systemctl enable --now --system diarizer.service
 ```
 
 Privacy Policy (7 days, prune anything older than 6 days = 24 * 60 * 6 = 8640 minutes). Append the following


### PR DESCRIPTION
- [it appears that] on upgrading we must manually `systemctl disable
diarizer; systemctl enable diarizer`
- [it appears that] we must explicitly set the user and group to
diarizer:diarizer; on the bright side we don't need to run as setuid
- fixes a bug where `go build ibmjson` would fail because there was already a directory of the same name.

I am not sure of the changes in this commit; some are important,
others merely cosmetic

When the SSL cert expires because the IPv6 addr changes, need to
temporary turn of the 301 redirect from HTTP to HTTPS in `nginx.conf`
to avoid being redirected to an invalid cert when running
`/etc/cron.weekly/letsencrypt.sh`

fixes:
```
Aug 20 15:14:28 test speechbroker: docker: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Post http://%2Fvar%2Frun%2Fdocker.sock/v1.30/containers/create: dial unix /var/run/docker.sock: connect: permission denied.
```