### PR TITLE
Server availability is checked every 6 hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-[![speechbroker](https://ci.nono.io/api/v1/pipelines/BlabberTabber/jobs/unit/badge)](https://ci.nono.io/?groups=BlabberTabber)
+| Status  | Build  |
+|:---|:---|
+| [![speechbroker](https://ci.nono.io/api/v1/pipelines/BlabberTabber/jobs/unit/badge)](https://ci.nono.io/?groups=BlabberTabber) | Unit Tests
+| [![speechbroker](https://ci.nono.io/api/v1/pipelines/BlabberTabber/jobs/production-server/badge)](https://ci.nono.io/?groups=BlabberTabber) | Production Server |
+| [![speechbroker](https://ci.nono.io/api/v1/pipelines/BlabberTabber/jobs/test-server/badge)](https://ci.nono.io/?groups=BlabberTabber) | Test Server |
 
 # speechbroker
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -6,6 +6,8 @@ groups:
 - name: BlabberTabber
   jobs:
   - unit
+  - production-server
+  - test-server
 
 jobs:
 - name: unit
@@ -23,9 +25,44 @@ jobs:
       - name: src
       run:
         path: src/ci/tasks/test-unit.sh
+- name: production-server
+  plan:
+  - {get: src, trigger: true}
+  - {get: 6h,  trigger: true}
+  - task: upload-file
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: blabbertabber/golang-ginko
+      inputs:
+      - name: src
+      run:
+        path: curl
+        args: [ "-F", "meeting.wav=@/dev/null", "https://diarizer.com:9443/api/v1/upload" ]
+- name: test-server
+  plan:
+  - {get: src, trigger: true}
+  - {get: 6h,  trigger: true}
+  - task: upload-file
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: blabbertabber/golang-ginko
+      inputs:
+      - name: src
+      run:
+        path: curl
+        args: [ "-F", "meeting.wav=@/dev/null", "http://test.diarizer.com:8080/api/v1/upload" ]
 
 resources:
 - name: src
   type: git
   source:
     uri: https://github.com/blabbertabber/speechbroker
+- name: 6h
+  type: time
+  source: {interval: 6h}


### PR DESCRIPTION
- both test (test.diarizer.com) and production (diarizer.com) servers are tested
- CI (continuous integration) server results can be seen here: <https://ci.nono.io/teams/main/pipelines/BlabberTabber>
- results are also displayed in the project's README
- a zero-byte audio file is uploaded to the test server.
- test shortcomings: the server is checked that it's up and running and can receive a file; however, it does not test the processing of the file. For example, if Docker is broken and the server can't diarize the input, our test will wrongly show the build as passing. It's not perfect.
- it's a fancy wrapper around `curl`