### PR TITLE
Times are output'ed in ISO 8061-ish format

### DIFF
--- a/timesandsize/timesandsize.go
+++ b/timesandsize/timesandsize.go
@@ -4,16 +4,25 @@ package timesandsize
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"time"
 )
 
 type TimesAndSize struct {
-	WaveFileSizeInByte               int       `json:"wav_file_size_in_bytes"`
-	Diarizer                         string    `json:"diarizer"`
-	Transcriber                      string    `json:"transcriber"`
-	EstimatedTranscriptionFinishTime time.Time `json:"estimated_transcription_finish_time"`
-	EstimatedDiarizationFinishTime   time.Time `json:"estimated_diarization_finish_time"`
+	WaveFileSizeInByte               int      `json:"wav_file_size_in_bytes"`
+	Diarizer                         string   `json:"diarizer"`
+	Transcriber                      string   `json:"transcriber"`
+	EstimatedDiarizationFinishTime   JSONTime `json:"estimated_diarization_finish_time"`
+	EstimatedTranscriptionFinishTime JSONTime `json:"estimated_transcription_finish_time"`
+}
+
+type JSONTime time.Time
+
+func (t JSONTime) MarshalJSON() ([]byte, error) {
+	//do your serializing here
+	stamp := fmt.Sprintf("\"%s\"", time.Time(t).Format("2006-01-02T15:04:05-0700"))
+	return []byte(stamp), nil
 }
 
 func (tas *TimesAndSize) WriteTimesAndSizeToWriter(w io.Writer) {

--- a/timesandsize/timesandsize_test.go
+++ b/timesandsize/timesandsize_test.go
@@ -12,22 +12,27 @@ var _ = Describe("TimesAndSize", func() {
 	Context(".WriteTimesAndSizeToWriter", func() {
 		Context("When a writer is called on a valid TimesAndSize struct", func() {
 			It("writes out the JSON struct to the writer", func() {
-				const longForm = "Jan 2, 2006 at 3:04pm (MST)"
-				t, _ := time.Parse(longForm, "Sep 4, 2017 at 9:49am (PST)")
+				const longForm = "Mon Jan 2 15:04:05 -0700 MST 2006"
+				t, err := time.Parse(longForm, "Mon Sep 4 20:49:14 -0700 PDT 2017")
+				if err != nil {
+					panic(err)
+				}
 				tas := TimesAndSize{
 					Diarizer:                         "blah",
 					Transcriber:                      "blech",
 					WaveFileSizeInByte:               256,
-					EstimatedDiarizationFinishTime:   t,
-					EstimatedTranscriptionFinishTime: t,
+					EstimatedDiarizationFinishTime:   JSONTime(t),
+					EstimatedTranscriptionFinishTime: JSONTime(t.Add(time.Second)),
 				}
 				bytewriter := bytes.NewBuffer([]byte{})
 				tas.WriteTimesAndSizeToWriter(bytewriter)
 				jsonwritten := bytewriter.String()
 
-				expectation := `{"wav_file_size_in_bytes":256,"diarizer":"blah","transcriber":"blech",` +
-					`"estimated_transcription_finish_time":"2017-09-04T09:49:00Z",` +
-					`"estimated_diarization_finish_time":"2017-09-04T09:49:00Z"}`
+				expectation := `{` +
+					`"wav_file_size_in_bytes":256,"diarizer":"blah","transcriber":"blech",` +
+					`"estimated_diarization_finish_time":"2017-09-04T20:49:14-0700",` +
+					`"estimated_transcription_finish_time":"2017-09-04T20:49:15-0700"` +
+					`}`
 				Expect(jsonwritten).To(Equal(expectation))
 			})
 		})


### PR DESCRIPTION
- javascript _should_ be able to parse those dates https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse
- tests have a 1-second difference between transcription time & diarization time to avoid accidental swapping