### PR TITLE
Times and sizes are written to a path

### DIFF
--- a/timesandsize/timesandsize.go
+++ b/timesandsize/timesandsize.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"time"
+	"os"
 )
 
 type TimesAndSize struct {
@@ -33,6 +34,17 @@ func (tas *TimesAndSize) WriteTimesAndSizeToWriter(w io.Writer) {
 	buf := bytes.NewBuffer(b)
 	_, err = buf.WriteTo(w)
 	if err != nil {
+		panic(err)
+	}
+}
+
+func (tas *TimesAndSize) WriteTimesAndSizeToPath(tasPath string) {
+	file, err := os.Create(tasPath)
+	if err != nil {
+		panic(err)
+	}
+	tas.WriteTimesAndSizeToWriter(file)
+	if err = file.Close(); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
- important for signalling to javascript the estimated wait times.