### PR TITLE
Timing tests are more robust on slower CI VMs

### DIFF
--- a/httphandler/httphandler_test.go
+++ b/httphandler/httphandler_test.go
@@ -15,8 +15,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"time"
 	"path/filepath"
+	"time"
 )
 
 type fakeWriter struct {
@@ -207,14 +207,14 @@ var _ = Describe("Httphandler", func() {
 				tas, path := ftas.WriteTimesAndSizeToPathArgsForCall(0)
 				expectedTimesSizeFilePath := filepath.FromSlash("/c/d/fake-uuid/times_and_size.json")
 				Expect(path).To(Equal(expectedTimesSizeFilePath))
-				Expect(time.Time(time.Time(tas.EstimatedDiarizationFinishTime)).Round(time.Millisecond)).To(Equal(
+				Expect(time.Time(time.Time(tas.EstimatedDiarizationFinishTime)).Round(time.Millisecond * 10)).To(Equal(
 					time.Now().Add(
 						handler.Speedfactors.EstimatedDiarizationTime("Aalto", 65536)).
-						Round(time.Millisecond)))
-				Expect(time.Time(time.Time(tas.EstimatedTranscriptionFinishTime)).Round(time.Millisecond)).To(Equal(
+						Round(time.Millisecond * 10)))
+				Expect(time.Time(time.Time(tas.EstimatedTranscriptionFinishTime)).Round(time.Millisecond * 10)).To(Equal(
 					time.Now().Add(
 						handler.Speedfactors.EstimatedTranscriptionTime("CMUSphinx4", 65536)).
-						Round(time.Millisecond)))
+						Round(time.Millisecond * 10)))
 			})
 		})
 		Context("when using IBM for both transcription and Diarization", func() {


### PR DESCRIPTION
Our Concourse continuous integration server's containers are too slow to
have timing assertions within a millisecond, causing false-positive
failures, so we make the test coarser and only measure centiseconds
(hundredths of seconds).

Example failure: <https://ci.nono.io/teams/main/pipelines/BlabberTabber/jobs/unit/builds/50>

fixes:
```
Httphandler /go/src/github.com/blabbertabber/speechbroker/httphandler/httphandler_test.go:234
  ServeHTTP /go/src/github.com/blabbertabber/speechbroker/httphandler/httphandler_test.go:233
    when using Aalto + CMU Sphinx
    /go/src/github.com/blabbertabber/speechbroker/httphandler/httphandler_test.go:219
      invokes the diarizer runner with the correct arguments [It]
      /go/src/github.com/blabbertabber/speechbroker/httphandler/httphandler_test.go:218

      Expected
          <time.Time>: 2017-09-16T21:20:06.547Z
      to equal
          <time.Time>: 2017-09-16T21:20:06.548Z
```