### PR TITLE
⏱ measure processing time ratios

### DIFF
--- a/speedfactors/speedfactors.go
+++ b/speedfactors/speedfactors.go
@@ -38,7 +38,7 @@ func ReadCredsFromReader(r io.Reader) (creds Speedfactors, err error) {
 // the following functions return time.Duration whose underlying type is int64 (nanosecs),
 func (sf Speedfactors) EstimatedDiarizationTime(diarizer string, soundFileSizeinBytes int64) time.Duration {
 	if val, ok := sf.Diarizer[diarizer]; ok {
-		return time.Duration(int64(val*float64(soundFileSizeinBytes)*1e9) / 32000)
+		return meetingLength(int64(val * float64(soundFileSizeinBytes)))
 	} else {
 		panic(fmt.Sprintf("I couldn't find Diarizer[\"%s\"]!", diarizer))
 	}
@@ -46,8 +46,16 @@ func (sf Speedfactors) EstimatedDiarizationTime(diarizer string, soundFileSizein
 
 func (sf Speedfactors) EstimatedTranscriptionTime(transcriber string, soundFileSizeinBytes int64) time.Duration {
 	if val, ok := sf.Transcriber[transcriber]; ok {
-		return time.Duration(int64(val*float64(soundFileSizeinBytes)*1e9) / 32000)
+		return meetingLength(int64(val * float64(soundFileSizeinBytes)))
 	} else {
 		panic(fmt.Sprintf("I couldn't find Transcriber[\"%s\"]!", transcriber))
 	}
+}
+
+func ProcessingRatio(start time.Time, finish time.Time, meetingWaveFileSize int64) float64 {
+	return float64(finish.Sub(start)) / float64((meetingLength(meetingWaveFileSize)))
+}
+
+func meetingLength(soundFileSizeinBytes int64) time.Duration {
+	return time.Duration(soundFileSizeinBytes * 1e9 / 32000)
 }

--- a/speedfactors/speedfactors_test.go
+++ b/speedfactors/speedfactors_test.go
@@ -89,4 +89,12 @@ var _ = Describe("Speedfactors", func() {
 			Expect(sf.EstimatedTranscriptionTime("CMUSphinx4", 19200000)).To(Equal(time.Minute * 80))
 		})
 	})
+	Context("ProcessingRatio", func() {
+		It("Returns the ratio of the length of processing to length of meeting", func() {
+			// 60 minutes file, takes 20 minutes to process
+			// Oh yeah baby, accurate to within 0.00000001%!
+			Expect(ProcessingRatio(time.Now(), time.Now().Add(time.Minute*20), 32000*60*60)).
+				Should(BeNumerically("~", 0.33333333333, 0.0000000001))
+		})
+	})
 })


### PR DESCRIPTION
We are interested in tracking how long diarization and transcription
take relative to the length of the recorded meeting. For example,
If a ten-minute meeting takes 5 minutes to diarize, then the ratio
is 0.5.

We like to record the information so that we can later collect it
and fine-tune the numbers for different machines. For example, we
expect our vultr.com machine (test.diarizer.com) to be much slower
than our ESXi machine (diarizer.com)

Notes
- test a floating point number (an integer-only test won't uncover
  bugs from division + conversion(int64, time.Duration, float64)
- added a WaitGroup for the final go func() which writes out the times
  to allow a consistent number of times to test that CreateWriter() was
  called (yes, it's only for testing).
- used channels — Concurrent programming for the win!