### PR TITLE
`ServeHTTP` calls `http.Error()`, not `panic()`

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,10 +1,10 @@
 package main
 
-// curl -F "a=1234" https://test.diarizer.com:9443/api/v1/upload
 // curl -F "meeting.wav=@/dev/null" http://test.diarizer.com:8080/api/v1/upload
 // curl -F "meeting.wav=@/Users/cunnie/Google Drive/BlabberTabber/ICSI-diarizer-sample-meeting.wav" -H "diarizer: Aalto" -H "transcriber: CMUSphinx4" http://test.diarizer.com:8080/api/v1/upload
 // curl -F "meeting.wav=@/Users/cunnie/Google Drive/BlabberTabber/ICSI-diarizer-sample-meeting.wav" -H "diarizer: Aalto" -H "transcriber: CMUSphinx4" https://diarizer.com:9443/api/v1/upload
 // curl --trace - -F "meeting.wav=@/dev/null" http://test.diarizer.com:8080/api/v1/upload
+// curl -v -F "a=1234" http://test.diarizer.com:8080/api/v1/upload # to see "500"
 // cleanup: sudo -u diarizer find /var/blabbertabber -name "*-*-*" -exec rm -rf {} \;
 
 import (

--- a/speedfactors/speedfactors.go
+++ b/speedfactors/speedfactors.go
@@ -3,6 +3,7 @@ package speedfactors
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -36,19 +37,19 @@ func ReadCredsFromReader(r io.Reader) (creds Speedfactors, err error) {
 }
 
 // the following functions return time.Duration whose underlying type is int64 (nanosecs),
-func (sf Speedfactors) EstimatedDiarizationTime(diarizer string, soundFileSizeinBytes int64) time.Duration {
+func (sf Speedfactors) EstimatedDiarizationTime(diarizer string, soundFileSizeinBytes int64) (time.Duration, error) {
 	if val, ok := sf.Diarizer[diarizer]; ok {
-		return meetingLength(int64(val * float64(soundFileSizeinBytes)))
+		return meetingLength(int64(val * float64(soundFileSizeinBytes))), nil
 	} else {
-		panic(fmt.Sprintf("I couldn't find Diarizer[\"%s\"]!", diarizer))
+		return time.Duration(0), errors.New(fmt.Sprintf("I couldn't find Diarizer[\"%s\"]!", diarizer))
 	}
 }
 
-func (sf Speedfactors) EstimatedTranscriptionTime(transcriber string, soundFileSizeinBytes int64) time.Duration {
+func (sf Speedfactors) EstimatedTranscriptionTime(transcriber string, soundFileSizeinBytes int64) (time.Duration, error) {
 	if val, ok := sf.Transcriber[transcriber]; ok {
-		return meetingLength(int64(val * float64(soundFileSizeinBytes)))
+		return meetingLength(int64(val * float64(soundFileSizeinBytes))), nil
 	} else {
-		panic(fmt.Sprintf("I couldn't find Transcriber[\"%s\"]!", transcriber))
+		return time.Duration(0), errors.New(fmt.Sprintf("I couldn't find Transcriber[\"%s\"]!", transcriber))
 	}
 }
 


### PR DESCRIPTION
- It's the canonical Golang way to handle errors in an HTTP server:
  <https://golang.org/doc/articles/wiki/#tmp_9>
- `http.Error()` is better: the user can see what went wrong,
  and often the user is me or Brendan. `panic()` is suboptimal
  because it forces to search logs on the server to find out what
  happened. And I have no idea where those logs are kept.
- An easy way to trigger the error is to upload a file without
  setting the diarizer or transcriber:
```
curl -vF "a=1234" http://test.diarizer.com:8080/api/v1/upload
```
- Added example command to see `500` `Internal Server Error`