### PR TITLE
Update aalto-speech dockerfile

### DIFF
--- a/assets/aalto-speech/Dockerfile
+++ b/assets/aalto-speech/Dockerfile
@@ -14,9 +14,13 @@ LABEL authors="Brian Cunnie <brian.cunnie@gmail.com>, Brendan Cunnie <saintbrend
 
 CMD ["/bin/bash"]
 
+# for converting audio files to wav
+RUN dnf install -y https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
+RUN dnf install -y ffmpeg
+
 # required development tools
 RUN dnf groupinstall -y "Development Tools"; \
-	dnf install -y cmake \
+	dnf install -y https://kojipkgs.fedoraproject.org//packages/cmake/2.8.12.2/2.fc21/x86_64/cmake-2.8.12.2-2.fc21.x86_64.rpm \
 	    SDL-devel \
 	    python-devel \
 	    lapack-devel \


### PR DESCRIPTION
- install ffmpeg so spk-diarization2.py can convert other audo files to
wav
- ensure we install cmake28 since now dnf just installs cmake3 which
breaks the build

